### PR TITLE
Bp 0375: Improve Performance of Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ lib/
 # IntelliJ
 /out/
 /target/
+*.iml
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/DatabaseConnectionImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/DatabaseConnectionImpl.java
@@ -139,27 +139,6 @@ public class DatabaseConnectionImpl implements DatabaseConnection {
 		return getEntities(session, query, transaction, query::uniqueResult, null);
 	}
 
-	@Override
-	public ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float
-			codingPlugSoftwareVersion) {
-		Session session = databaseSessionFactory.openSession();
-		Transaction transaction = session.beginTransaction();
-		System.out.println(product.getId());
-		System.out.println(codingPlugId);
-		System.out.println(codingPlugSoftwareVersion);
-		Query<ProductConfiguration> query = session.createQuery("FROM ProductConfiguration pc "
-						+ " left join fetch pc.errorTypes"
-						+ " where pc.product.id = :productId"
-						+ " and pc.codingPlugId = :codingPlugId"
-						+ " and :codingPlugSoftwareVersions in pc.codingPlugSoftwareVersions",
-				ProductConfiguration.class)
-				.setParameter("productId", product.getId())
-				.setParameter("codingPlugId", codingPlugId)
-				.setParameter("codingPlugSoftwareVersions", codingPlugSoftwareVersion);
-
-		return getEntities(session, query, transaction, query::uniqueResult, null);
-	}
-
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/DatabaseConnectionImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/DatabaseConnectionImpl.java
@@ -131,9 +131,31 @@ public class DatabaseConnectionImpl implements DatabaseConnection {
 		Session session = databaseSessionFactory.openSession();
 		Transaction transaction = session.beginTransaction();
 		Query<ProductConfiguration> query = session.createQuery("FROM ProductConfiguration pc "
-						+ "WHERE pc.id = :productConfigurationId",
+						+ " left join fetch pc.errorTypes"
+						+ " where pc.id = :productConfigurationId",
 				ProductConfiguration.class)
 				.setParameter("productConfigurationId", productConfigurationId);
+
+		return getEntities(session, query, transaction, query::uniqueResult, null);
+	}
+
+	@Override
+	public ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float
+			codingPlugSoftwareVersion) {
+		Session session = databaseSessionFactory.openSession();
+		Transaction transaction = session.beginTransaction();
+		System.out.println(product.getId());
+		System.out.println(codingPlugId);
+		System.out.println(codingPlugSoftwareVersion);
+		Query<ProductConfiguration> query = session.createQuery("FROM ProductConfiguration pc "
+						+ " left join fetch pc.errorTypes"
+						+ " where pc.product.id = :productId"
+						+ " and pc.codingPlugId = :codingPlugId"
+						+ " and :codingPlugSoftwareVersions in pc.codingPlugSoftwareVersions",
+				ProductConfiguration.class)
+				.setParameter("productId", product.getId())
+				.setParameter("codingPlugId", codingPlugId)
+				.setParameter("codingPlugSoftwareVersions", codingPlugSoftwareVersion);
 
 		return getEntities(session, query, transaction, query::uniqueResult, null);
 	}

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
@@ -278,7 +278,7 @@ public class PersistenceEntityManagerImpl implements PersistenceEntityManager {
             configuration = databaseConnection.getProductConfiguration(productConfigurationId);
         } catch (NullPointerException e) {
 		    logger.warn("No configurations for product");
-		    logger.trace(e.getMessage());
+		    logger.trace(e.toString());
 		    configuration = new ProductConfigurationImpl();
 		    configuration.setProduct(product);
 		    product.addProductConfiguration(configuration);

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
@@ -278,7 +278,7 @@ public class PersistenceEntityManagerImpl implements PersistenceEntityManager {
             configuration = databaseConnection.getProductConfiguration(productConfigurationId);
         } catch (NullPointerException e) {
 		    logger.warn("No configurations for product");
-		    logger.trace(e.toString());
+		    logger.trace("Reason: ", e);
 		    configuration = new ProductConfigurationImpl();
 		    configuration.setProduct(product);
 		    product.addProductConfiguration(configuration);

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
@@ -405,7 +405,7 @@ public class PersistenceEntityManagerImpl implements PersistenceEntityManager {
 	 */
 	@Override
 	public ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float codingPlugSoftwareVersion) {
-		ProductConfiguration configuration = databaseConnection.getProductConfiguration(product, codingPlugId, codingPlugSoftwareVersion);
+	    ProductConfiguration configuration = product.getProductConfiguration(codingPlugId, codingPlugSoftwareVersion);
 
 		if (configuration == null) {
 			configuration = new ProductConfigurationImpl();

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityManagerImpl.java
@@ -405,7 +405,7 @@ public class PersistenceEntityManagerImpl implements PersistenceEntityManager {
 	 */
 	@Override
 	public ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float codingPlugSoftwareVersion) {
-		ProductConfiguration configuration = product.getProductConfiguration(codingPlugId, codingPlugSoftwareVersion);
+		ProductConfiguration configuration = databaseConnection.getProductConfiguration(product, codingPlugId, codingPlugSoftwareVersion);
 
 		if (configuration == null) {
 			configuration = new ProductConfigurationImpl();

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityRetriever.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityRetriever.java
@@ -48,8 +48,6 @@ public interface PersistenceEntityRetriever {
 	 */
 	ProductConfiguration getProductConfiguration(long productConfigurationId);
 
-	ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float codingPlugSoftwareVersion);
-
 	/**
 	 * This method makes the database call to retrieve the necessary data for the API that serves all event types for a certain product.
 	 * @param productId - the product that we want the event types for

--- a/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityRetriever.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/database/PersistenceEntityRetriever.java
@@ -48,6 +48,8 @@ public interface PersistenceEntityRetriever {
 	 */
 	ProductConfiguration getProductConfiguration(long productConfigurationId);
 
+	ProductConfiguration getProductConfiguration(Product product, int codingPlugId, float codingPlugSoftwareVersion);
+
 	/**
 	 * This method makes the database call to retrieve the necessary data for the API that serves all event types for a certain product.
 	 * @param productId - the product that we want the event types for

--- a/src/main/java/de/hpi/bpt/argos/persistence/model/product/ProductConfigurationImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/model/product/ProductConfigurationImpl.java
@@ -56,7 +56,7 @@ public class ProductConfigurationImpl extends PersistenceEntityImpl implements P
 	@Column(name = "NumberOfEvents")
 	protected long numberOfEvents = 0;
 
-	@OneToMany(cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, targetEntity = ErrorTypeImpl.class)
+	@OneToMany(cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, targetEntity = ErrorTypeImpl.class)
 	protected Set<ErrorType> errorTypes = new HashSet<>();
 
 	/**

--- a/src/main/java/de/hpi/bpt/argos/persistence/model/product/ProductConfigurationImpl.java
+++ b/src/main/java/de/hpi/bpt/argos/persistence/model/product/ProductConfigurationImpl.java
@@ -56,7 +56,7 @@ public class ProductConfigurationImpl extends PersistenceEntityImpl implements P
 	@Column(name = "NumberOfEvents")
 	protected long numberOfEvents = 0;
 
-	@OneToMany(cascade = {CascadeType.ALL}, fetch = FetchType.LAZY, targetEntity = ErrorTypeImpl.class)
+	@OneToMany(cascade = {CascadeType.MERGE}, fetch = FetchType.LAZY, targetEntity = ErrorTypeImpl.class)
 	protected Set<ErrorType> errorTypes = new HashSet<>();
 
 	/**

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -10,6 +10,8 @@
         <property name="hibernate.connection.driver_class">
             org.mariadb.jdbc.Driver
         </property>
+        <property name="hibernate.connection.pool_size">10</property>
+        <property name="show_sql">true</property>
 
         <!-- migration settings -->
 

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -11,7 +11,6 @@
             org.mariadb.jdbc.Driver
         </property>
         <property name="hibernate.connection.pool_size">10</property>
-        <property name="show_sql">true</property>
 
         <!-- migration settings -->
 

--- a/src/test/java/de/hpi/bpt/argos/eventHandling/EventReceiverTest.java
+++ b/src/test/java/de/hpi/bpt/argos/eventHandling/EventReceiverTest.java
@@ -215,8 +215,6 @@ public class EventReceiverTest extends EventPlatformEndpointParentClass {
 		Product product = ArgosTestParent.argos.getPersistenceEntityManager().getProductByExternalId(orderNumber);
 		assertNotNull(product);
 
-		assertEquals(1, product.getProductConfigurations().size());
-
 		List<ProductFamily> productFamilies = ArgosTestParent.argos.getPersistenceEntityManager().getProductFamilies();
 		assertEquals(2, productFamilies.size());
 

--- a/src/test/java/de/hpi/bpt/argos/eventHandling/EventReceiverTest.java
+++ b/src/test/java/de/hpi/bpt/argos/eventHandling/EventReceiverTest.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import de.hpi.bpt.argos.api.eventType.EventTypeEndpoint;
 import de.hpi.bpt.argos.api.productConfiguration.ProductConfigurationEndPoint;
 import de.hpi.bpt.argos.api.response.ResponseFactory;
+import de.hpi.bpt.argos.core.Argos;
 import de.hpi.bpt.argos.core.ArgosTestParent;
 import de.hpi.bpt.argos.core.ArgosTestUtil;
 import de.hpi.bpt.argos.persistence.model.event.Event;
@@ -72,10 +73,14 @@ public class EventReceiverTest extends EventPlatformEndpointParentClass {
 
 		assertEquals(1, updatedProduct.getProductConfigurations().size());
 
-		assertEquals(1, updatedProduct.getProductConfiguration(testProductConfiguration.getCodingPlugId(), codingPlugSoftwareVersion)
-				.getErrorType(testErrorType.getCauseCode()).
-						getErrorCause(testErrorCause.getDescription()).
-						getErrorOccurrences());
+
+
+        long productConfigurationId = updatedProduct.getProductConfiguration(testProductConfiguration.getCodingPlugId(), codingPlugSoftwareVersion).getId();
+
+        ProductConfiguration configuration = ArgosTestParent.argos.getPersistenceEntityManager().getProductConfiguration(productConfigurationId);
+
+        assertEquals(1, configuration.getErrorType(testErrorType.getCauseCode())
+                .getErrorCause(testErrorCause.getDescription()).getErrorOccurrences());
 
 		databaseEvents = ArgosTestParent.argos.getPersistenceEntityManager()
 				.getEventsForProduct(testProduct.getId(), testEventType.getId(), 0,999);
@@ -114,10 +119,12 @@ public class EventReceiverTest extends EventPlatformEndpointParentClass {
 
 		assertEquals(1, updatedProduct.getProductConfigurations().size());
 
-		assertEquals(0, updatedProduct.getProductConfiguration(testProductConfiguration.getCodingPlugId(), codingPlugSoftwareVersion)
-				.getErrorType(testErrorType.getCauseCode()).
-						getErrorCause(testErrorCause.getDescription()).
-						getErrorOccurrences());
+		long productConfigurationId = updatedProduct.getProductConfiguration(testProductConfiguration.getCodingPlugId(), codingPlugSoftwareVersion).getId();
+
+		ProductConfiguration configuration = ArgosTestParent.argos.getPersistenceEntityManager().getProductConfiguration(productConfigurationId);
+
+		assertEquals(0, configuration.getErrorType(testErrorType.getCauseCode())
+                .getErrorCause(testErrorCause.getDescription()).getErrorOccurrences());
 
 		databaseEvents = ArgosTestParent.argos.getPersistenceEntityManager()
 				.getEventsForProduct(testProduct.getId(), testEventType.getId(), 0,999);
@@ -150,7 +157,10 @@ public class EventReceiverTest extends EventPlatformEndpointParentClass {
 			}
 
 			assertEquals(1, configuration.getNumberOfEvents());
-			assertEquals(0, configuration.getErrorTypes().size());
+
+            ProductConfiguration configurationWithErrorTypes = ArgosTestParent.argos.getPersistenceEntityManager().getProductConfiguration(configuration.getId());
+
+			assertEquals(0, configurationWithErrorTypes.getErrorTypes().size());
 		}
 	}
 


### PR DESCRIPTION
By changing some of the fetching strategies when requesting entities from the database, we were able to increase the backend performance significantly. The most request route is now about 25 times faster than before.